### PR TITLE
Release GitHub Actionsのトリガーを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,7 @@ name: Release
 
 on:
   push:
-    branches: [ release ]
-  pull_request:
-    branches: [ release ]
+    tags: [ v* ]
 
 jobs:
   build:


### PR DESCRIPTION
## WHY

リリースのためにブランチを切っていたが、ブランチが多く管理が困難だったり、ブランチを切る作業、タグを発行する作業に属人性が出てしまっていた（ただし開発者は一人）。

## WHAT

タグを発行すれば（`npm version (major|minor|patch)`）リリースさせるようにした。